### PR TITLE
[Spotify] Add insert playlist route

### DIFF
--- a/controllers/spotify/playlist.go
+++ b/controllers/spotify/playlist.go
@@ -47,7 +47,7 @@ func (p spotifyProvider) GetPlaylist(w http.ResponseWriter, r *http.Request) {
 
 	playlist, err := p.Service.GetPlaylist(playlistId, accessToken.Value)
 	if err != nil {
-		errMsg := "Error getting playlist"
+		errMsg := "Error getting playlist: " + err.Error()
 		http.Error(w, errMsg, http.StatusInternalServerError)
 		fmt.Println(errMsg)
 		return
@@ -55,7 +55,7 @@ func (p spotifyProvider) GetPlaylist(w http.ResponseWriter, r *http.Request) {
 
 	playlistJson, err := json.Marshal(playlist)
 	if err != nil {
-		errMsg := "Error marshalling playlist"
+		errMsg := "Error marshalling playlist: " + err.Error()
 		http.Error(w, errMsg, http.StatusInternalServerError)
 		fmt.Println(errMsg)
 		return
@@ -110,7 +110,7 @@ func (p spotifyProvider) InsertPlaylist(w http.ResponseWriter, r *http.Request) 
 	}
 	playlistId := urlParts[2]
 
-	err = p.Service.InsertPlaylist(playlistId, username.Value, accessToken.Value, playlist)
+	err = p.Service.InsertPlaylist(playlistId, accessToken.Value, playlist)
 	if err != nil {
 		errMsg := fmt.Sprintf("Error inserting musics into playlist: %s", err)
 		http.Error(w, errMsg, http.StatusInternalServerError)

--- a/controllers/spotify/playlist.go
+++ b/controllers/spotify/playlist.go
@@ -47,16 +47,18 @@ func (p spotifyProvider) GetPlaylist(w http.ResponseWriter, r *http.Request) {
 
 	playlist, err := p.Service.GetPlaylist(playlistId, accessToken.Value)
 	if err != nil {
-		errMsg := "Error getting playlist: " + err.Error()
+		errMsg := "Error getting playlist"
 		http.Error(w, errMsg, http.StatusInternalServerError)
+		errMsg += fmt.Sprintf(": %s", err.Error())
 		fmt.Println(errMsg)
 		return
 	}
 
 	playlistJson, err := json.Marshal(playlist)
 	if err != nil {
-		errMsg := "Error marshalling playlist: " + err.Error()
+		errMsg := "Error marshalling playlist"
 		http.Error(w, errMsg, http.StatusInternalServerError)
+		errMsg += fmt.Sprintf(": %s", err.Error())
 		fmt.Println(errMsg)
 		return
 	}

--- a/controllers/spotify/playlist.go
+++ b/controllers/spotify/playlist.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	spotifyModels "github.com/DevOps-Group-D/YouToFy-API/models/spotify"
+	"github.com/DevOps-Group-D/YouToFy-API/models"
 	"github.com/DevOps-Group-D/YouToFy-API/services/authentication"
 )
 
@@ -67,7 +67,7 @@ func (p spotifyProvider) GetPlaylist(w http.ResponseWriter, r *http.Request) {
 }
 
 func (p spotifyProvider) InsertPlaylist(w http.ResponseWriter, r *http.Request) {
-	var playlist *spotifyModels.Playlist
+	var playlist *models.Playlist
 
 	err := json.NewDecoder(r.Body).Decode(&playlist)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -51,6 +51,9 @@ func main() {
 	// Registering post routes
 	router.Post("/save", providerImpl.Save)
 
+	// Registering patch routes
+	router.Patch("/playlist/{playlistId}", providerImpl.InsertPlaylist)
+
 	fmt.Println("Listening and serving on port", cfg.ApiConfig.Port)
 	http.ListenAndServe(fmt.Sprintf(":%s", cfg.ApiConfig.Port), router)
 }

--- a/models/playlist.go
+++ b/models/playlist.go
@@ -1,4 +1,4 @@
-package spotify
+package models
 
 import "time"
 

--- a/models/spotify/playlist.go
+++ b/models/spotify/playlist.go
@@ -38,7 +38,3 @@ type Image struct {
 	URL    string `json:"url"`
 	Width  int    `json:"width"`
 }
-
-type Tracks struct {
-	Items []Track `json:"items"`
-}

--- a/models/spotify/search.go
+++ b/models/spotify/search.go
@@ -1,0 +1,13 @@
+package spotify
+
+type FoundMusics struct {
+	Tracks Tracks `json:"tracks"`
+}
+
+type Tracks struct {
+	Items []FoundItem `json:"items"`
+}
+
+type FoundItem struct {
+	URI string `json:"uri"`
+}

--- a/services/spotify/spotify.go
+++ b/services/spotify/spotify.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/DevOps-Group-D/YouToFy-API/configs"
+	"github.com/DevOps-Group-D/YouToFy-API/models"
 	spotifyModels "github.com/DevOps-Group-D/YouToFy-API/models/spotify"
 	spotifyRepository "github.com/DevOps-Group-D/YouToFy-API/repositories/spotify"
 	"github.com/DevOps-Group-D/YouToFy-API/utils"
@@ -93,7 +94,7 @@ func (s *SpotifyService) GetAccessToken(username string, code string) (*spotifyM
 	return &accessTokenRes, nil
 }
 
-func (s *SpotifyService) GetPlaylist(playlistId string, accessToken string) (*spotifyModels.Playlist, error) {
+func (s *SpotifyService) GetPlaylist(playlistId string, accessToken string) (*models.Playlist, error) {
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf(GET_PLAYLISTS_URL, playlistId), nil)
 	if err != nil {
 		return nil, err
@@ -115,7 +116,7 @@ func (s *SpotifyService) GetPlaylist(playlistId string, accessToken string) (*sp
 		return nil, fmt.Errorf("Error making get spotify playlist request: %s", errorBody)
 	}
 
-	var playlist spotifyModels.Playlist
+	var playlist models.Playlist
 
 	err = json.NewDecoder(res.Body).Decode(&playlist)
 	if err != nil {
@@ -125,7 +126,7 @@ func (s *SpotifyService) GetPlaylist(playlistId string, accessToken string) (*sp
 	return &playlist, nil
 }
 
-func (s *SpotifyService) InsertPlaylist(playlistId string, accessToken string, playlist *spotifyModels.Playlist) error {
+func (s *SpotifyService) InsertPlaylist(playlistId string, accessToken string, playlist *models.Playlist) error {
 	insertPlaylistRequest := spotifyModels.InsertPlaylistRequest{Position: 0}
 
 	for _, item := range playlist.Items {

--- a/services/spotify/spotify.go
+++ b/services/spotify/spotify.go
@@ -125,7 +125,7 @@ func (s *SpotifyService) GetPlaylist(playlistId string, accessToken string) (*sp
 	return &playlist, nil
 }
 
-func (s *SpotifyService) InsertPlaylist(playlistId string, username string, accessToken string, playlist *spotifyModels.Playlist) error {
+func (s *SpotifyService) InsertPlaylist(playlistId string, accessToken string, playlist *spotifyModels.Playlist) error {
 	insertPlaylistRequest := spotifyModels.InsertPlaylistRequest{Position: 0}
 
 	for _, item := range playlist.Items {
@@ -133,9 +133,9 @@ func (s *SpotifyService) InsertPlaylist(playlistId string, username string, acce
 		musicName := music.Name
 		artistName := music.Artists[0].Name
 
-		musicFound, err := findMusic(musicName, artistName)
+		musicFound, err := findMusic(musicName, artistName, accessToken)
 		if err != nil {
-			fmt.Printf("Could not found %s from %s\n", musicName, artistName)
+			fmt.Printf("Could not found %s from %s, Error: %s\n", musicName, artistName, err)
 			continue
 		}
 		musicFoundUri := musicFound.URI
@@ -155,30 +155,50 @@ func (s *SpotifyService) InsertPlaylist(playlistId string, username string, acce
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
 	req.Header.Set("Content-Type", "application/json")
 
+	res, err := utils.Client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("spotify API returned status %d", res.StatusCode)
+	}
+
 	return nil
 }
 
-func findMusic(name string, artist string) (*spotifyModels.Track, error) {
+func findMusic(name string, artist string, accessToken string) (*spotifyModels.FoundItem, error) {
 	queryParams := url.Values{}
 	queryParams.Set("q", fmt.Sprintf("%s %s", name, artist))
+	queryParams.Set("limit", "1")
 	queryParams.Set("type", "track")
 
 	req, err := http.NewRequest(http.MethodGet, SEARCH_MUSIC_URL+"?"+queryParams.Encode(), nil)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
 
 	res, err := utils.Client.Do(req)
 	if err != nil {
-		return nil, nil
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("spotify API returned status %d", res.StatusCode)
 	}
 
-	var tracks *spotifyModels.Tracks
+	var foundMusics *spotifyModels.FoundMusics
 
-	err = json.NewDecoder(res.Body).Decode(&tracks)
+	err = json.NewDecoder(res.Body).Decode(&foundMusics)
 	if err != nil {
 		return nil, err
 	}
 
-	return &tracks.Items[0], nil
+	if foundMusics == nil || len(foundMusics.Tracks.Items) == 0 {
+		return nil, fmt.Errorf("no tracks found for '%s' by '%s'", name, artist)
+	}
+
+	return &foundMusics.Tracks.Items[0], nil
 }


### PR DESCRIPTION
## [Feat]: Add insert playlist route

- [X] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [X] New and existing unit tests pass locally with my changes.

---

### What does this PR do?

It adds the "InsertPlaylist" patch route that receives a playlist and a playlist Id and insert the given playlist on the playlist with the received playlistId

Additionally, it makes the playlist struct a `commom` struct for all providers

### How to test it?

1. Login with Spotify and on our application
2. Take the playlistID of your playlist clicking on share playlist and getting it from url
3. Call PATCH route "/playlist/{playlistId}" passing a Playlist as a JSON on body
4. Verify that the given playlist was add on the new playlist

### Screenshots (if applicable)

[Image1]: Old playlist
[Image2]: New playlist
<img width="960" height="770" alt="image" src="https://github.com/user-attachments/assets/841574d8-cbc6-4e5b-9c08-a51a8ae9822a" />

<img width="984" height="795" alt="image" src="https://github.com/user-attachments/assets/c0f17ced-e202-4319-b992-edaac6104088" />

