### PR TITLE
[youtube] Add insert playlist route

### DIFF
--- a/controllers/youtube/playlist.go
+++ b/controllers/youtube/playlist.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	youtubeModels "github.com/DevOps-Group-D/YouToFy-API/models/youtube"
 	authenticationService "github.com/DevOps-Group-D/YouToFy-API/services/authentication"
 	youtubeService "github.com/DevOps-Group-D/YouToFy-API/services/youtube"
 	"golang.org/x/oauth2"
@@ -44,8 +45,8 @@ func (p youtubeProvider) GetPlaylist(w http.ResponseWriter, r *http.Request) {
 		fmt.Println(errMsg)
 		return
 	}
-
-	playlist, err := youtubeService.GetPlaylist(playlistId, authCode)
+	var playlist youtubeModels.Playlist
+	playlist, err = youtubeService.GetPlaylist(playlistId, authCode)
 	if err != nil {
 		http.Error(w, "error retrieving playlist: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -62,9 +63,68 @@ func (p youtubeProvider) GetPlaylist(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// TODO
 func (p youtubeProvider) InsertPlaylist(w http.ResponseWriter, r *http.Request) {
-	fmt.Println("[Youtube] InsertPlaylist not implemented")
+	var playlist youtubeModels.Playlist
+
+	err := json.NewDecoder(r.Body).Decode(&playlist)
+	if err != nil {
+		errMsg := fmt.Sprintf("Error decoding playlist request body: %s", err.Error())
+		http.Error(w, errMsg, http.StatusBadRequest)
+		fmt.Println(errMsg)
+		return
+	}
+
+	username, err := r.Cookie("username")
+	if err != nil {
+		errMsg := fmt.Sprintf("Error getting username cookie: %s", err.Error())
+		http.Error(w, errMsg, http.StatusBadRequest)
+		fmt.Println(errMsg)
+		return
+	}
+
+	authorized := authenticationService.Authorize(username.Value, r.Cookies())
+	if !authorized {
+		errMsg := "Error: unauthorized"
+		http.Error(w, errMsg, http.StatusBadRequest)
+		fmt.Println(errMsg)
+		return
+	}
+
+	var authCode *oauth2.Token
+	accessToken, err := r.Cookie("youtube_access_token")
+	if err != nil {
+		errMsg := fmt.Sprintf("Error getting youtube_access_token cookie: %s", err.Error())
+		http.Error(w, errMsg, http.StatusUnauthorized)
+		fmt.Println(errMsg)
+		return
+	}
+	authCode = tokenFromHeader(accessToken.Value, "Bearer", accessToken.Expires)
+	if authCode == nil {
+		errMsg := "Error: Unauthorized"
+		http.Error(w, errMsg, http.StatusUnauthorized)
+		fmt.Println(errMsg)
+		return
+	}
+
+	urlParts := strings.Split(r.URL.String(), "/")
+	if len(urlParts) < 3 || urlParts[2] == "" {
+		errMsg := "Error getting playlistId in URL"
+		http.Error(w, errMsg, http.StatusBadRequest)
+		fmt.Println(errMsg)
+		return
+	}
+	playlistId := urlParts[2]
+
+	err = youtubeService.InsertPlaylist(playlistId, authCode, playlist)
+	if err != nil {
+		errMsg := fmt.Sprintf("Error inserting musics into playlist: %s", err)
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		fmt.Println(errMsg)
+		return
+	}
+
+	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(200)
 }
 
 func tokenFromHeader(accessToken string, tokenType string, expiry time.Time) *oauth2.Token {

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ func main() {
 
 	// Registering post routes
 	router.Post("/save", providerImpl.Save)
+	router.Post("/playlist/{playlistId}", providerImpl.InsertPlaylist)
 
 	fmt.Println("Listening and serving on port", cfg.ApiConfig.Port)
 	http.ListenAndServe(fmt.Sprintf(":%s", cfg.ApiConfig.Port), router)

--- a/main.go
+++ b/main.go
@@ -50,7 +50,9 @@ func main() {
 
 	// Registering post routes
 	router.Post("/save", providerImpl.Save)
-	router.Post("/playlist/{playlistId}", providerImpl.InsertPlaylist)
+
+	// Registering patch routes
+	router.Patch("/playlist/{playlistId}", providerImpl.InsertPlaylist)
 
 	fmt.Println("Listening and serving on port", cfg.ApiConfig.Port)
 	http.ListenAndServe(fmt.Sprintf(":%s", cfg.ApiConfig.Port), router)

--- a/models/youtube/playlist.go
+++ b/models/youtube/playlist.go
@@ -1,0 +1,44 @@
+package youtube
+
+import "time"
+
+type Playlist struct {
+	PlaylistID string `json:"playlist_id"`
+	Items      []Item `json:"items,omitempty"`
+	Uri        string `json:"uri"`
+}
+
+type Item struct {
+	AddedAt time.Time `json:"added_at"`
+	Track   Track     `json:"track"`
+}
+
+type Track struct {
+	ID         string   `json:"id"`
+	Name       string   `json:"name"`
+	Artists    []Artist `json:"artists"`
+	Album      Album    `json:"album"`
+	DurationMs int      `json:"duration_ms"`
+	URI        string   `json:"uri"`
+}
+
+type Artist struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type Album struct {
+	ID     string  `json:"id"`
+	Name   string  `json:"name"`
+	Images []Image `json:"images"`
+}
+
+type Image struct {
+	Height int    `json:"height"`
+	URL    string `json:"url"`
+	Width  int    `json:"width"`
+}
+
+type Tracks struct {
+	Items []Track `json:"items"`
+}

--- a/models/youtube/playlist.go
+++ b/models/youtube/playlist.go
@@ -38,7 +38,3 @@ type Image struct {
 	URL    string `json:"url"`
 	Width  int    `json:"width"`
 }
-
-type Tracks struct {
-	Items []Track `json:"items"`
-}

--- a/repositories/youtube/credentials.go
+++ b/repositories/youtube/credentials.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	INSERT_QUERY_YOUTUBECREDENTIALS = `INSERT INTO youtube (account_username, access_token) VALUES ($1, $2)`
-	SELECT_QUERY_YOUTUBECREDENTIALS = `SELECT * FROM youtube count WHERE username = $1`
+	SELECT_QUERY_YOUTUBECREDENTIALS = `SELECT * FROM youtube count WHERE account_username = $1`
 	UPDATE_QUERY_YOUTUBECREDENTIALS = `UPDATE youtube SET access_token = $2 WHERE account_username = $1`
 )
 
@@ -47,7 +47,7 @@ func GetYouTubeCredentials(username string) (*models.YouTubeCredentials, error) 
 	}
 
 	youTubeCredentials := &models.YouTubeCredentials{}
-	err = row.Scan(&youTubeCredentials.AccessToken)
+	err = row.Scan(&youTubeCredentials.AccountUsername, &youTubeCredentials.AccessToken)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,10 @@ func GetYouTubeCredentials(username string) (*models.YouTubeCredentials, error) 
 	return youTubeCredentials, nil
 }
 
-func UpdateYouTubeCredentials(youTubeCredentials *models.YouTubeCredentials) error {
+func UpdateYouTubeCredentials(
+	Username string,
+	AccessToken string,
+) error {
 	conn, err := database.Connect()
 	if err != nil {
 		return err
@@ -65,7 +68,7 @@ func UpdateYouTubeCredentials(youTubeCredentials *models.YouTubeCredentials) err
 	defer conn.Close()
 
 	row := conn.QueryRow(UPDATE_QUERY_YOUTUBECREDENTIALS,
-		youTubeCredentials.AccountUsername, youTubeCredentials.AccessToken)
+		Username, AccessToken)
 	if row.Err() != nil {
 		return row.Err()
 	}

--- a/services/youtube/youtubeCredentials.go
+++ b/services/youtube/youtubeCredentials.go
@@ -3,14 +3,12 @@ package servicesAcc
 import (
 	"fmt"
 	"log"
-	"os"
 
 	"github.com/DevOps-Group-D/YouToFy-API/configs"
 	youtubeRepository "github.com/DevOps-Group-D/YouToFy-API/repositories/youtube"
 
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 	"google.golang.org/api/youtube/v3"
 )
@@ -93,19 +91,6 @@ func GetWebTokenFromCode(code string) (*oauth2.Token, error) {
 		return nil, fmt.Errorf("unable to exchange code for token: %v", err)
 	}
 	return token, nil
-}
-
-// TODO: Remove it
-func loadConfig() (*oauth2.Config, error) {
-	b, err := os.ReadFile("client_secret.json")
-	if err != nil {
-		log.Fatalf("Unable to read client secret file: %v", err)
-	}
-	config, err := google.ConfigFromJSON(b, youtube.YoutubeReadonlyScope)
-	if err != nil {
-		log.Fatalf("Unable to parse client secret file to config: %v", err)
-	}
-	return config, nil
 }
 
 func loadFromConfig() (*oauth2.Config, error) {

--- a/services/youtube/youtubeCredentials.go
+++ b/services/youtube/youtubeCredentials.go
@@ -155,7 +155,6 @@ func InsertPlaylist(playlistId string, token *oauth2.Token, playlist youtubeMode
 			fmt.Println(err.Error())
 			continue
 		}
-		// musicFoundUri := musicFound.URI
 	}
 
 	return nil
@@ -184,10 +183,7 @@ func GetYouTubeCredentials(username string) (*oauth2.Token, error) {
 
 func SaveToken(username string, token *oauth2.Token) error {
 	_, Credentials_err := youtubeRepository.GetYouTubeCredentials(username)
-	// fmt.Println(res)
-	// fmt.Printf("will update credentials?: %v\n", Credentials_err)
 	if Credentials_err == nil {
-		// fmt.Println("updating credentials")
 		err := youtubeRepository.UpdateYouTubeCredentials(username, token.AccessToken)
 		if err != nil {
 			return fmt.Errorf("error updating YouTube credentials: %v", err)

--- a/services/youtube/youtubeCredentials.go
+++ b/services/youtube/youtubeCredentials.go
@@ -5,7 +5,10 @@ import (
 	"log"
 
 	"github.com/DevOps-Group-D/YouToFy-API/configs"
+	youtubeModels "github.com/DevOps-Group-D/YouToFy-API/models/spotify"
 	youtubeRepository "github.com/DevOps-Group-D/YouToFy-API/repositories/youtube"
+
+	"time"
 
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
@@ -30,31 +33,82 @@ func GetAuthURL() string {
 	return authURL
 }
 
-func GetPlaylist(paylistId string, token *oauth2.Token) ([]string, error) {
+func GetPlaylist(paylistId string, token *oauth2.Token) (youtubeModels.Playlist, error) {
 	config, err := loadFromConfig()
 	if err != nil {
-		return nil, fmt.Errorf("error loading config: %v", err)
+		return youtubeModels.Playlist{}, fmt.Errorf("error loading config: %v", err)
 	}
 	ctx := context.Background()
 	client := config.Client(ctx, token)
 	opts := option.WithHTTPClient(client)
 	service, err := youtube.NewService(ctx, opts)
 	if err != nil {
-		return nil, fmt.Errorf("error creating YouTube service: %v", err)
+		return youtubeModels.Playlist{}, fmt.Errorf("error creating YouTube service: %v", err)
 	}
 	part := []string{"snippet,contentDetails"}
 	call := service.PlaylistItems.List(part).PlaylistId(paylistId)
-	var videoTitles []string
+	var playlist youtubeModels.Playlist
+	playlist.PlaylistID = paylistId
+	playlist.Uri = paylistId
+	var items []youtubeModels.Item
+	playlist.Items = items
 	err = call.Pages(ctx, func(response *youtube.PlaylistItemListResponse) error {
 		for _, item := range response.Items {
-			videoTitles = append(videoTitles, item.Snippet.Title)
+			artist := youtubeModels.Artist{
+				ID:   item.Snippet.VideoOwnerChannelId,
+				Name: item.Snippet.VideoOwnerChannelTitle,
+			}
+			var artists []youtubeModels.Artist
+			artists = append(artists, artist)
+			var images []youtubeModels.Image
+			default_thumb := item.Snippet.Thumbnails.Default
+			if default_thumb != nil {
+				image := youtubeModels.Image{
+					Height: int(default_thumb.Height),
+					URL:    default_thumb.Url,
+					Width:  int(default_thumb.Width),
+				}
+				images = append(images, image)
+			}
+			standard_thumb := item.Snippet.Thumbnails.Standard
+			if standard_thumb != nil {
+				image := youtubeModels.Image{
+					Height: int(standard_thumb.Height),
+					URL:    standard_thumb.Url,
+					Width:  int(standard_thumb.Width),
+				}
+				images = append(images, image)
+			}
+			album := youtubeModels.Album{
+				ID:     "youtube",
+				Name:   "youtube",
+				Images: images,
+			}
+
+			track := youtubeModels.Track{
+				ID:         item.Id,
+				Name:       item.Snippet.Title,
+				Artists:    artists,
+				Album:      album,
+				DurationMs: 0,
+				URI:        item.ContentDetails.VideoId,
+			}
+			publishedAtTime, err := time.Parse(time.RFC3339, item.Snippet.PublishedAt)
+			if err != nil {
+				publishedAtTime = time.Time{}
+			}
+			item := youtubeModels.Item{
+				AddedAt: publishedAtTime,
+				Track:   track,
+			}
+			playlist.Items = append(playlist.Items, item)
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving playlist items: %v", err)
+		return youtubeModels.Playlist{}, fmt.Errorf("error retrieving playlist items: %v", err)
 	}
-	return videoTitles, nil
+	return playlist, nil
 
 }
 
@@ -70,12 +124,23 @@ func GetYouTubeCredentials(username string) (*oauth2.Token, error) {
 }
 
 func SaveToken(username string, token *oauth2.Token) error {
-	err := youtubeRepository.InsertYouTubeCredentials(
-		username,
-		token.AccessToken,
-	)
-	if err != nil {
-		return fmt.Errorf("error saving YouTube credentials: %v", err)
+	_, Credentials_err := youtubeRepository.GetYouTubeCredentials(username)
+	// fmt.Println(res)
+	// fmt.Printf("will update credentials?: %v\n", Credentials_err)
+	if Credentials_err == nil {
+		// fmt.Println("updating credentials")
+		err := youtubeRepository.UpdateYouTubeCredentials(username, token.AccessToken)
+		if err != nil {
+			return fmt.Errorf("error updating YouTube credentials: %v", err)
+		}
+	} else {
+		err := youtubeRepository.InsertYouTubeCredentials(
+			username,
+			token.AccessToken,
+		)
+		if err != nil {
+			return fmt.Errorf("error saving YouTube credentials: %v", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## [Feat]: Add insert playlist route

- [X] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable).
- [X] New and existing unit tests pass locally with my changes.

---

### What does this PR do?

It adds the "InsertPlaylist" patch route that receives a playlist and a playlist Id and insert the given playlist on the playlist with the received playlistId

### How to test it?

*(Step-by-step instructions on how to manually test the changes introduced by this PR. Include any specific setup, commands, or data needed.)*

1. Login with Youtube and on our application
2. Take the playlistID of your playlist clicking on share playlist and getting it from url
3. Call PATCH route "/playlist/{playlistId}" passing a Playlist as a JSON on body
3.1. you can get a playlist json through the GET route at /playlist/{playlistID}
4. Verify that the given playlist was added on the new playlist

### Screenshots

[Image1]: Old playlist
[Image2]: New playlist
<img width="585" alt="image" src="https://github.com/user-attachments/assets/476e5bed-67e7-40cf-a6de-fcbf16cf29c2" />
<img width="556" alt="image" src="https://github.com/user-attachments/assets/a16d4f8c-50cc-4e2b-8b2e-c4e050f7eb1d" />

---

